### PR TITLE
fix: missing special apostrophe (\u0301) inside regex

### DIFF
--- a/lib/limax.js
+++ b/lib/limax.js
@@ -17,7 +17,7 @@ module.exports = function(text, opt) {
   }
 
   // Remove apostrophes contained within a word
-  text = text.replace(/(\S)['\u2018\u2019\u201A\u201B\u2032\u2035](\S)/g, '$1$2');
+  text = text.replace(/(\S)['\u2018\u2019\u201A\u201B\u2032\u2035\u0301](\S)/g, '$1$2');
 
   // Break out any numbers contained within a word
   if (separateNumbers) {


### PR DESCRIPTION
Hello !

While using your js librairy for one of my projet i found out that this string 'Pop brésilienne header' get converted to 'pop-bre-silienne-header' because of the apostrophe \u0301 which is not removed but converted as a dash.

I didn't create an issue on your Github repo, because i found how to fix it, this is why i made this pull request.

I did run the test on my local computer with one more line of test than the ones you use :

```
var tests = {
  ...
  'Pop brésilienne header': 'pop-bresilienne-header'
};
```
