### PR TITLE
Fix types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,4 +14,4 @@ type Options = {
 
 declare function slug(text: string, opt?: Options): string;
 
-export = slug;
+export default slug;

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lib/"
   ],
   "exports": {
+    "types": "./index.d.ts",
     "import": "./lib/limax.mjs",
-    "require": "./lib/index.cjs",
-    "types": "./index.d.ts"
+    "require": "./lib/index.cjs"
   },
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "exports": {
     "import": "./lib/limax.mjs",
-    "require": "./lib/index.cjs"
+    "require": "./lib/index.cjs",
+    "types": "./index.d.ts"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
See : https://github.com/lovell/limax/pull/51#issuecomment-3344522843

With 4.2.0 and Typescript enabled on my project, I now get this error because it doesn't find declarations files: 

```
Could not find a declaration file for module 'limax'.  '[...]/node_modules/limax/lib/limax.mjs' implicitly has an 'any' type.
  There are types at '[...]/node_modules/limax/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'limax' library may need to update its package.json or typings.

4 import slug from 'limax'
```
